### PR TITLE
Use childViewControllerForStatusBarStyle/childViewControllerForStatusBarHidden

### DIFF
--- a/TWTSideMenuViewController/TWTSideMenuViewController.m
+++ b/TWTSideMenuViewController/TWTSideMenuViewController.m
@@ -151,16 +151,21 @@ static NSTimeInterval const kDefaultSwapAnimationClosedDuration = 0.35;
 
 #pragma mark - Status Bar management
 
-- (UIStatusBarStyle)preferredStatusBarStyle
+- (UIViewController *)childViewControllerForStatusBarStyle
 {
-    if ([self respondsToSelector:@selector(preferredStatusBarStyle)]) {
-        if (self.open) {
-            return self.menuViewController.preferredStatusBarStyle;
-        } else {
-            return self.mainViewController.preferredStatusBarStyle;
-        }
+    if (self.open) {
+        return self.menuViewController;
     } else {
-        return UIStatusBarStyleDefault;
+        return self.mainViewController;
+    }
+}
+
+- (UIViewController *)childViewControllerForStatusBarHidden
+{
+    if (self.open) {
+        return self.menuViewController;
+    } else {
+        return self.mainViewController;
     }
 }
 


### PR DESCRIPTION
I think this is what Apple seems to intend you to do when you're creating container view controllers rather than calling preferredStatusBarStyle directly on a child view controller.

It gives you a lot more flexibility allows you to either define the -preferredStatusBarStyle in the main/menu controllers and it will work as before or have them just return another childViewControllerForStatusBarStyle (ie. my main view controller is a navigation controller and I want to either return light or dark depending on the top view controller)
