### PR TITLE
Menu display issue

### DIFF
--- a/TWTSideMenuViewController-Sample/TWTAppDelegate.h
+++ b/TWTSideMenuViewController-Sample/TWTAppDelegate.h
@@ -7,7 +7,7 @@
 //
 
 #import <UIKit/UIKit.h>
-#import "TWTSideMenuViewController.h";
+#import "TWTSideMenuViewController.h"
 
 @interface TWTAppDelegate : UIResponder <UIApplicationDelegate, TWTSideMenuViewControllerDelegate>
 

--- a/TWTSideMenuViewController-Sample/TWTMainViewController.m
+++ b/TWTSideMenuViewController-Sample/TWTMainViewController.m
@@ -39,7 +39,7 @@ static NSString * const kTableViewCellIdentifier = @"com.twotoasters.sampleCell"
     UIViewController *viewController = [[UIViewController alloc] initWithNibName:nil bundle:nil];
     viewController.view.backgroundColor = [UIColor redColor];
     [self presentViewController:viewController animated:YES completion:^{
-        double delayInSeconds = 5.0;
+        double delayInSeconds = 2.0;
         dispatch_time_t popTime = dispatch_time(DISPATCH_TIME_NOW, (int64_t)(delayInSeconds * NSEC_PER_SEC));
         dispatch_after(popTime, dispatch_get_main_queue(), ^(void){
             [viewController dismissViewControllerAnimated:YES completion:nil];

--- a/TWTSideMenuViewController-Sample/TWTMainViewController.m
+++ b/TWTSideMenuViewController-Sample/TWTMainViewController.m
@@ -27,7 +27,24 @@ static NSString * const kTableViewCellIdentifier = @"com.twotoasters.sampleCell"
     UIBarButtonItem *openItem = [[UIBarButtonItem alloc] initWithTitle:@"Open" style:UIBarButtonItemStylePlain target:self action:@selector(openButtonPressed)];
     self.navigationItem.leftBarButtonItem = openItem;
     
+    UIBarButtonItem *testItem = [[UIBarButtonItem alloc] initWithTitle:@"Show Modal" style:UIBarButtonItemStylePlain target:self action:@selector(testButtonAction)];
+    self.navigationItem.rightBarButtonItem = testItem;
+   
     [self.tableView registerClass:[UITableViewCell class] forCellReuseIdentifier:kTableViewCellIdentifier];
+}
+
+- (void)testButtonAction
+{
+    // Test with presenting a modal view controller when in the context of a menuviewcontroller
+    UIViewController *viewController = [[UIViewController alloc] initWithNibName:nil bundle:nil];
+    viewController.view.backgroundColor = [UIColor redColor];
+    [self presentViewController:viewController animated:YES completion:^{
+        double delayInSeconds = 1.0;
+        dispatch_time_t popTime = dispatch_time(DISPATCH_TIME_NOW, (int64_t)(delayInSeconds * NSEC_PER_SEC));
+        dispatch_after(popTime, dispatch_get_main_queue(), ^(void){
+            [viewController dismissViewControllerAnimated:YES completion:nil];
+        });
+    }];
 }
 
 - (void)openButtonPressed

--- a/TWTSideMenuViewController-Sample/TWTMainViewController.m
+++ b/TWTSideMenuViewController-Sample/TWTMainViewController.m
@@ -66,7 +66,7 @@ static NSString * const kTableViewCellIdentifier = @"com.twotoasters.sampleCell"
 
 - (void)tableView:(UITableView *)tableView willDisplayCell:(UITableViewCell *)cell forRowAtIndexPath:(NSIndexPath *)indexPath
 {
-    cell.textLabel.text = [NSString stringWithFormat:@"Row %i", indexPath.row + 1];
+    cell.textLabel.text = [NSString stringWithFormat:@"Row %li", indexPath.row + 1];
 }
 
 @end

--- a/TWTSideMenuViewController-Sample/TWTMainViewController.m
+++ b/TWTSideMenuViewController-Sample/TWTMainViewController.m
@@ -39,7 +39,7 @@ static NSString * const kTableViewCellIdentifier = @"com.twotoasters.sampleCell"
     UIViewController *viewController = [[UIViewController alloc] initWithNibName:nil bundle:nil];
     viewController.view.backgroundColor = [UIColor redColor];
     [self presentViewController:viewController animated:YES completion:^{
-        double delayInSeconds = 1.0;
+        double delayInSeconds = 5.0;
         dispatch_time_t popTime = dispatch_time(DISPATCH_TIME_NOW, (int64_t)(delayInSeconds * NSEC_PER_SEC));
         dispatch_after(popTime, dispatch_get_main_queue(), ^(void){
             [viewController dismissViewControllerAnimated:YES completion:nil];

--- a/TWTSideMenuViewController-Sample/TWTMenuViewController.m
+++ b/TWTSideMenuViewController-Sample/TWTMenuViewController.m
@@ -56,8 +56,19 @@
 
 - (void)changeButtonPressed
 {
-    UINavigationController *controller = [[UINavigationController alloc] initWithRootViewController:[TWTMainViewController new]];
-    [self.sideMenuViewController setMainViewController:controller animated:YES closeMenu:YES];
+    // Test with presenting a modal view controller when in the context of a menuviewcontroller
+    UIViewController *viewController = [[UIViewController alloc] initWithNibName:nil bundle:nil];
+    viewController.view.backgroundColor = [UIColor redColor];
+    [self presentViewController:viewController animated:YES completion:^{
+        double delayInSeconds = 5.0;
+        dispatch_time_t popTime = dispatch_time(DISPATCH_TIME_NOW, (int64_t)(delayInSeconds * NSEC_PER_SEC));
+        dispatch_after(popTime, dispatch_get_main_queue(), ^(void){
+            [viewController dismissViewControllerAnimated:YES completion:^{
+                UINavigationController *controller = [[UINavigationController alloc] initWithRootViewController:[TWTMainViewController new]];
+                [self.sideMenuViewController setMainViewController:controller animated:YES closeMenu:YES];
+            }];
+        });
+    }];
 }
 
 - (void)closeButtonPressed

--- a/TWTSideMenuViewController-Sample/TWTMenuViewController.m
+++ b/TWTSideMenuViewController-Sample/TWTMenuViewController.m
@@ -52,15 +52,29 @@
     [changeButton setTitleColor:[UIColor blackColor] forState:UIControlStateNormal];
     [changeButton addTarget:self action:@selector(changeButtonPressed) forControlEvents:UIControlEventTouchUpInside];
     [self.view addSubview:changeButton];
+    
+    UIButton *modalButton = [UIButton buttonWithType:UIButtonTypeSystem];
+    modalButton.frame = CGRectMake(10.0f, 300.0f, 200.0f, 44.0f);
+    [modalButton setTitle:@"Modal Test" forState:UIControlStateNormal];
+    [modalButton setBackgroundColor:[UIColor redColor]];
+    [modalButton setTitleColor:[UIColor blackColor] forState:UIControlStateNormal];
+    [modalButton addTarget:self action:@selector(modalButtonPressed) forControlEvents:UIControlEventTouchUpInside];
+    [self.view addSubview:modalButton];
 }
 
 - (void)changeButtonPressed
+{
+    UINavigationController *controller = [[UINavigationController alloc] initWithRootViewController:[TWTMainViewController new]];
+    [self.sideMenuViewController setMainViewController:controller animated:YES closeMenu:YES];
+}
+
+- (void)modalButtonPressed
 {
     // Test with presenting a modal view controller when in the context of a menuviewcontroller
     UIViewController *viewController = [[UIViewController alloc] initWithNibName:nil bundle:nil];
     viewController.view.backgroundColor = [UIColor redColor];
     [self presentViewController:viewController animated:YES completion:^{
-        double delayInSeconds = 5.0;
+        double delayInSeconds = 2.0;
         dispatch_time_t popTime = dispatch_time(DISPATCH_TIME_NOW, (int64_t)(delayInSeconds * NSEC_PER_SEC));
         dispatch_after(popTime, dispatch_get_main_queue(), ^(void){
             [viewController dismissViewControllerAnimated:YES completion:^{

--- a/TWTSideMenuViewController-Sample/TWTSideMenuViewController-Sample-Info.plist
+++ b/TWTSideMenuViewController-Sample/TWTSideMenuViewController-Sample-Info.plist
@@ -31,6 +31,9 @@
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 	<key>UISupportedInterfaceOrientations~ipad</key>
 	<array>

--- a/TWTSideMenuViewController/TWTSideMenuViewController.m
+++ b/TWTSideMenuViewController/TWTSideMenuViewController.m
@@ -108,15 +108,6 @@ static NSTimeInterval const kDefaultSwapAnimationClosedDuration = 0.35;
 
     if (self.open) {
         [self removeOverlayButtonFromMainViewController];
-
-        [UIView animateWithDuration:duration animations:^{
-            // Effectively closes the menu and reapplies transform. This is a half measure to get around the problem of new view controllers getting pushed on to the hierarchy without the proper height navigation.
-            self.menuViewController.view.transform = [self closeTransformForMenuView];
-            self.containerView.transform = CGAffineTransformIdentity;
-        } completion:^(BOOL finished) {
-            self.menuViewController.view.center = (CGPoint) { CGRectGetMidX(self.view.bounds), CGRectGetMidY(self.view.bounds) };
-            self.menuViewController.view.bounds = self.view.bounds;
-        }];
     } else {
         [self updateMenuViewWithTransform:CGAffineTransformIdentity];
     }
@@ -125,24 +116,12 @@ static NSTimeInterval const kDefaultSwapAnimationClosedDuration = 0.35;
 - (void)didRotateFromInterfaceOrientation:(UIInterfaceOrientation)fromInterfaceOrientation
 {
     if (self.open) {
-        [UIView animateWithDuration:0.2 animations:^{
-            self.menuViewController.view.transform = CGAffineTransformIdentity;
-            self.containerView.transform = [self openTransformForView:self.containerView];
-        } completion:^(BOOL finished) {
-            [self addShadowToViewController:self.mainViewController];
-            [self addOverlayButtonToMainViewController];
-        }];
+        [self rotateTransformForOpenPosition];
+        [self addShadowToViewController:self.mainViewController];
+        [self addOverlayButtonToMainViewController];
     } else {
         [self updateMenuViewWithTransform:CGAffineTransformIdentity];
         [self addShadowToViewController:self.mainViewController];
-    }
-}
-
-- (void)willAnimateRotationToInterfaceOrientation:(UIInterfaceOrientation)toInterfaceOrientation duration:(NSTimeInterval)duration
-{
-    // Reset the menu view's frame while the menu is closed. This keeps the menu position correctly when the menu is closed.
-    if (!self.open) {
-        [self updateMenuViewWithTransform:[self closeTransformForMenuView]];
     }
 }
 
@@ -196,6 +175,32 @@ static NSTimeInterval const kDefaultSwapAnimationClosedDuration = 0.35;
     return CGAffineTransformScale(newTransform, transformSize, transformSize);
 }
 
+- (void)transformToOpenPosition
+{
+    self.menuViewController.view.transform = CGAffineTransformIdentity;
+    self.containerView.transform = [self openTransformForView:self.containerView];
+}
+
+- (void)transformToClosePosition
+{
+    self.menuViewController.view.transform = [self closeTransformForMenuView];
+    self.containerView.transform = CGAffineTransformIdentity;
+}
+
+- (void)rotateTransformForOpenPosition
+{
+    // reset the transform back to it's invert (undo the transform)
+    self.containerView.transform = CGAffineTransformConcat(self.containerView.transform, CGAffineTransformInvert(self.containerView.transform));
+    
+    // transform to the newly updated transform for the current orientation
+    self.containerView.transform = [self openTransformForView:self.containerView];
+    
+    // update view hierarchy
+    self.menuViewController.view.transform = CGAffineTransformIdentity;
+    self.containerView.bounds = self.view.bounds;
+    self.mainViewController.view.frame = self.containerView.bounds;
+}
+
 - (void)openMenuAnimated:(BOOL)animated completion:(void (^)(BOOL finished))completion
 {
     if (self.open) {
@@ -207,11 +212,10 @@ static NSTimeInterval const kDefaultSwapAnimationClosedDuration = 0.35;
     }
     
     self.open = YES;
-    self.menuViewController.view.transform = [self closeTransformForMenuView];
+    [self transformToClosePosition];
 
     void (^openMenuBlock)(void) = ^{
-        self.menuViewController.view.transform = CGAffineTransformIdentity;
-        self.containerView.transform = [self openTransformForView:self.containerView];
+        [self transformToOpenPosition];
     };
     
     void (^openCompleteBlock)(BOOL) = ^(BOOL finished) {
@@ -259,8 +263,7 @@ static NSTimeInterval const kDefaultSwapAnimationClosedDuration = 0.35;
     [self removeOverlayButtonFromMainViewController];
     
     void (^closeMenuBlock)(void) = ^{
-        self.menuViewController.view.transform = [self closeTransformForMenuView];
-        self.containerView.transform = CGAffineTransformIdentity;
+        [self transformToClosePosition];
     };
     
     void (^closeCompleteBlock)(BOOL) = ^(BOOL finished) {
@@ -324,6 +327,7 @@ static NSTimeInterval const kDefaultSwapAnimationClosedDuration = 0.35;
     [self addViewController:incomingViewController];
     [self.containerView addSubview:incomingViewController.view];
 
+    self.containerView.bounds = self.view.bounds;
     incomingViewController.view.frame = self.containerView.bounds;
     
     //Create default animation curve.


### PR DESCRIPTION
I'm opening a pull request here with a few changes to start the conversation about getting the iPad fixes merged. 

I've fixed a few warnings here and there, and moved the modal presentation test to a third button in the menu. 

Known issue:
- If the app launches on iPad in Landscape orientation, the menu still presents with a white bar on the left of the screen. Rotating with the menu closed fixes this.
