### PR TITLE
Fix Xcode 6 warnings

### DIFF
--- a/TWTSideMenuViewController-Sample/TWTAppDelegate.h
+++ b/TWTSideMenuViewController-Sample/TWTAppDelegate.h
@@ -7,7 +7,7 @@
 //
 
 #import <UIKit/UIKit.h>
-#import "TWTSideMenuViewController.h";
+#import "TWTSideMenuViewController.h"
 
 @interface TWTAppDelegate : UIResponder <UIApplicationDelegate, TWTSideMenuViewControllerDelegate>
 

--- a/TWTSideMenuViewController-Sample/TWTMainViewController.m
+++ b/TWTSideMenuViewController-Sample/TWTMainViewController.m
@@ -49,7 +49,7 @@ static NSString * const kTableViewCellIdentifier = @"com.twotoasters.sampleCell"
 
 - (void)tableView:(UITableView *)tableView willDisplayCell:(UITableViewCell *)cell forRowAtIndexPath:(NSIndexPath *)indexPath
 {
-    cell.textLabel.text = [NSString stringWithFormat:@"Row %i", indexPath.row + 1];
+    cell.textLabel.text = [NSString stringWithFormat:@"Row %li", indexPath.row + 1];
 }
 
 @end


### PR DESCRIPTION
Remove extraneous semicolon on import in TWTAppDelegate.h
Fix format string for cell.textLabel in TWTMainViewController.m
